### PR TITLE
Add offline handling and metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Getting your Unsplash Photoframe up and running is straightforward:
 1.  **Obtain API Keys:** Get your Unsplash API Key and Secret from the [Unsplash API Documentation](https://unsplash.com/documentation).
 2.  **Configure:** Access the package's configuration page on your Info-Beamer node to input your API keys, set display preferences, choose categories, and define layouts.
 3.  **Deployment:** Deploy this package directory to your Info-Beamer device. For instructions, refer to the [Info-Beamer documentation on building packages](https://info-beamer.com/doc/building-packages).
-4.  **Run:** Start the package on your Info-Beamer node.
+4.  **Run:** Execute `fetch_unsplash.py` regularly (e.g., via cron) to download new images and then start the package on your Info-Beamer node.
 
 For more detailed setup instructions and advanced configurations, please refer to the comments within the code.
 

--- a/fetch_unsplash.py
+++ b/fetch_unsplash.py
@@ -1,63 +1,82 @@
-This script queries the Unsplash API for random photos and stores them in the
-``images/`` directory. Already downloaded images are reused to keep bandwidth
-low. It respects a daily download limit defined in ``config.json``.
+#!/usr/bin/env python3
+"""Fetch images from Unsplash and cache them locally.
+
+This utility downloads random images via the Unsplash API and stores them in the
+``images/`` directory. Downloaded images are reused if already present to reduce
+bandwidth usage. The daily download amount is limited through ``config.json``.
 """
+
+from __future__ import annotations
+
 import json
 import os
-import random
 import sys
 from datetime import datetime
 from pathlib import Path
-from urllib.request import urlopen, Request
+from urllib.error import URLError
+from urllib.request import Request, urlopen
 
-CONFIG_FILE = Path(__file__).with_name('config.json')
-IMAGE_DIR = Path(__file__).with_name('images')
+CONFIG_FILE = Path(__file__).with_name("config.json")
+IMAGE_DIR = Path(__file__).with_name("images")
 IMAGE_DIR.mkdir(exist_ok=True)
+LOG_FILE = Path(__file__).with_name("download.log")
+OFFLINE_FLAG = Path(__file__).with_name("offline.flag")
 
 
-def load_config():
+def load_config() -> dict:
+    """Load configuration from ``config.json``."""
     with CONFIG_FILE.open() as f:
         return json.load(f)
 
 
-def save_log(msg: str) -> None:
-    """Append log message with timestamp."""
-    with Path('download.log').open('a') as f:
+def log(msg: str) -> None:
+    """Append a timestamped log message to ``download.log``."""
+    with LOG_FILE.open("a") as f:
         f.write(f"{datetime.utcnow().isoformat()} {msg}\n")
 
 
 def download_image(url: str, filename: Path) -> None:
-    req = Request(url, headers={'User-Agent': 'Info-Beamer Photoframe'})
-    with urlopen(req) as resp, open(filename, 'wb') as out:
+    """Download ``url`` to ``filename``."""
+    req = Request(url, headers={"User-Agent": "Info-Beamer Photoframe"})
+    with urlopen(req) as resp, open(filename, "wb") as out:
         out.write(resp.read())
 
 
 def fetch_images(count: int, api_key: str) -> None:
+    """Fetch ``count`` random images using ``api_key``."""
     for _ in range(count):
-        url = f"https://api.unsplash.com/photos/random?client_id={api_key}"
+        api_url = f"https://api.unsplash.com/photos/random?client_id={api_key}"
         try:
-            with urlopen(url) as resp:
+            with urlopen(api_url) as resp:
                 data = json.loads(resp.read().decode())
-                img_url = data['urls']['full']
-                name = data['id'] + '.jpg'
-                target = IMAGE_DIR / name
-                if not target.exists():
-                    download_image(img_url, target)
-                    save_log(f"downloaded {name}")
-        except Exception as err:
-            save_log(f"error: {err}")
-            return
+            img_url = data["urls"]["full"]
+            name = data["id"] + ".jpg"
+            target = IMAGE_DIR / name
+            if not target.exists():
+                download_image(img_url, target)
+                log(f"downloaded {name}")
+                if OFFLINE_FLAG.exists():
+                    OFFLINE_FLAG.unlink()
+        except URLError as err:
+            log(f"network error: {err}")
+            OFFLINE_FLAG.touch()
+            break
+        except Exception as err:  # noqa: BLE001
+            log(f"error: {err}")
+            OFFLINE_FLAG.touch()
+            break
 
 
-def main():
+def main() -> None:
     cfg = load_config()
-    api_key = cfg.get('unsplash_key', {}).get('value') or os.getenv('UNSPLASH_KEY')
+    api_key = cfg.get("unsplash_key", {}).get("value") or os.getenv("UNSPLASH_KEY")
     if not api_key:
-        print('Unsplash key missing')
+        print("Unsplash key missing")
         sys.exit(1)
-    daily = cfg.get('daily_limit', {}).get('value', 50)
+
+    daily = int(cfg.get("daily_limit", {}).get("value", 50))
     fetch_images(daily, api_key)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/info.json
+++ b/info.json
@@ -1,0 +1,8 @@
+{
+  "id": "unsplash-photoframe",
+  "name": "Unsplash Photoframe",
+  "description": "Displays photos from Unsplash with offline cache.",
+  "author": "Example Author",
+  "version": "1.0.0",
+  "main": "node.lua"
+}

--- a/node.lua
+++ b/node.lua
@@ -16,6 +16,12 @@ FONT = resource.load_font("Roboto-Regular.ttf")
 local image_list = {}
 local idx = 1
 local last_switch = sys.now()
+local offline = false
+
+local function check_offline()
+    local status, data = pcall(resource.load_file, "offline.flag")
+    offline = status and data ~= nil
+end
 
 function reload_images()
     image_list = {}
@@ -29,6 +35,9 @@ end
 node.event("file_change", function(filename)
     if filename:match("images/.*%.jpg") then
         reload_images()
+    end
+    if filename == "offline.flag" then
+        check_offline()
     end
 end)
 
@@ -49,6 +58,12 @@ function node.render()
     if img then
         img:draw(0, 0, NATIVE_WIDTH, NATIVE_HEIGHT, 1)
     end
+    if offline then
+        local msg = "OFFLINE MODE"
+        local w = math.floor(NATIVE_WIDTH / 2 - FONT:width(msg, 30) / 2)
+        FONT:write(w, 30, msg, 30, 1, 0, 0, 1)
+    end
 end
 
 reload_images()
+check_offline()

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "unsplash-photoframe",
+  "version": "1.0.0",
+  "description": "Info-Beamer package fetching images from Unsplash",
+  "license": "GPL-3.0-or-later",
+  "main": "node.lua"
+}


### PR DESCRIPTION
## Summary
- add `package.json` and `info.json` with basic metadata
- rewrite `fetch_unsplash.py` with proper header and offline flag support
- show an offline overlay in `node.lua`
- document running `fetch_unsplash.py` in README

## Testing
- `python3 -m py_compile fetch_unsplash.py`

------
https://chatgpt.com/codex/tasks/task_e_688b4776a35483208813c7fbdf7a4456